### PR TITLE
feat: add data lists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,8 @@ export * from "./promises.js";
 export * from "./strings.js";
 export * from "./timers.js";
 export * from "./types.js";
+
+export type { DataList } from "./lists/data-list.js";
+export { OptionGroup, optionGroup } from "./lists/option-group.js";
+export type { OptionList } from "./lists/option-list.js";
+export { Option, option } from "./lists/option.js";

--- a/src/lists/__tests__/option-group.test.ts
+++ b/src/lists/__tests__/option-group.test.ts
@@ -72,7 +72,7 @@ describe("optionGroup", () => {
 /**
  * Provides assertions for parsing data to an `OptionGroup`.
  */
-describe("Option", () => {
+describe("OptionGroup", () => {
 	it("can parse", () => {
 		// Arrange.
 		const options: DataList = [

--- a/src/lists/__tests__/option-group.test.ts
+++ b/src/lists/__tests__/option-group.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+
+import type { DataList } from "../data-list.js";
+import { OptionGroup, optionGroup } from "../option-group.js";
+import { option } from "../option.js";
+
+/**
+ * Provides assertions for creating an option group.
+ */
+describe("optionGroup", () => {
+	it("assigns type", () => {
+		// Arrange, act.
+		const opt = optionGroup({
+			disabled: true,
+			label: "Elgato",
+			options: [
+				option({ label: "Stream Deck", value: "sd" }),
+				optionGroup({
+					label: "Stream Deck +",
+					options: [
+						option({ value: "sd+xlr", label: "Stream Deck + XLR" }),
+						option({ value: "sd+usb", label: "Stream Deck + USB" }),
+					],
+				}),
+			],
+		});
+
+		// Assert.
+		expect(opt.type).toBe("option-group");
+		expect(opt.disabled).toBe(true);
+		expect(opt.label).toBe("Elgato");
+		expect(opt.options).toEqual([
+			{
+				type: "option",
+				label: "Stream Deck",
+				value: "sd",
+			},
+			{
+				type: "option-group",
+				label: "Stream Deck +",
+				options: [
+					{
+						type: "option",
+						label: "Stream Deck + XLR",
+						value: "sd+xlr",
+					},
+					{
+						type: "option",
+						label: "Stream Deck + USB",
+						value: "sd+usb",
+					},
+				],
+			},
+		]);
+	});
+
+	it("does not assign default", () => {
+		// Arrange, act.
+		const opt = optionGroup({
+			label: "Elgato",
+			options: [],
+		});
+
+		// Assert.
+		expect(opt.type).toBe("option-group");
+		expect(opt.disabled).toBeUndefined();
+		expect(opt.label).toBe("Elgato");
+		expect(opt.options).toEqual([]);
+	});
+});
+
+/**
+ * Provides assertions for parsing data to an `OptionGroup`.
+ */
+describe("Option", () => {
+	it("can parse", () => {
+		// Arrange.
+		const options: DataList = [
+			{
+				type: "option" as const,
+				label: "Stream Deck",
+				value: "sd",
+			},
+			{
+				type: "option-group" as const,
+				label: "Stream Deck +",
+				options: [
+					{
+						type: "option" as const,
+						label: "Stream Deck + XLR",
+						value: "sd+xlr",
+					},
+					{
+						type: "option" as const,
+						label: "Stream Deck + USB",
+						value: "sd+usb",
+					},
+				],
+			},
+		];
+
+		const data: OptionGroup = {
+			type: "option-group",
+			label: "Elgato",
+			disabled: false,
+			options,
+		};
+
+		// Act.
+		const optGroup = OptionGroup.parse(data);
+
+		// Assert
+		expect(optGroup.disabled).toBe(false);
+		expect(optGroup.type).toBe("option-group");
+		expect(optGroup.label).toBe("Elgato");
+		expect(optGroup.options).toEqual(options);
+	});
+
+	it("does not require disabled", () => {
+		// Arrange.
+		const data: OptionGroup = {
+			type: "option-group",
+			label: "Elgato",
+			options: [],
+		};
+
+		// Act.
+		const optGroup = OptionGroup.parse(data);
+
+		// Assert
+		expect(optGroup.disabled).toBeUndefined();
+		expect(optGroup.type).toBe("option-group");
+		expect(optGroup.label).toBe("Elgato");
+		expect(optGroup.options).toEqual([]);
+	});
+
+	it("requires label", () => {
+		// Arrange.
+		const data = {
+			type: "option-group",
+			options: [],
+		};
+
+		// Act, assert.
+		const result = OptionGroup.safeParse(data);
+		expect(result.success).toBe(false);
+	});
+
+	it("requires options", () => {
+		// Arrange.
+		const data = {
+			type: "option-group",
+			label: "Elgato",
+		};
+
+		// Act, assert.
+		const result = OptionGroup.safeParse(data);
+		expect(result.success).toBe(false);
+	});
+
+	it("requires valid options", () => {
+		// Arrange.
+		const data = {
+			type: "option-group",
+			label: "Elgato",
+			options: ["test"],
+		};
+
+		// Act, assert.
+		const result = OptionGroup.safeParse(data);
+		expect(result.success).toBe(false);
+	});
+
+	it("requires type", () => {
+		// Arrange.
+		const data = {
+			label: "Elgato",
+			options: [],
+		};
+
+		// Act, assert.
+		const result = OptionGroup.safeParse(data);
+		expect(result.success).toBe(false);
+	});
+});

--- a/src/lists/__tests__/option.test.ts
+++ b/src/lists/__tests__/option.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import { Option, option } from "../option.js";
+
+/**
+ * Provides assertions for creating an option.
+ */
+describe("option", () => {
+	it("assigns type", () => {
+		// Arrange, act.
+		const opt = option({
+			disabled: true,
+			label: "Elgato",
+			value: "elg",
+		});
+
+		// Assert.
+		expect(opt.type).toBe("option");
+		expect(opt.disabled).toBe(true);
+		expect(opt.label).toBe("Elgato");
+		expect(opt.value).toBe("elg");
+	});
+
+	it("does not assign default", () => {
+		// Arrange, act.
+		const opt = option({
+			label: "Elgato",
+			value: "elg",
+		});
+
+		// Assert.
+		expect(opt.type).toBe("option");
+		expect(opt.disabled).toBeUndefined();
+		expect(opt.label).toBe("Elgato");
+		expect(opt.value).toBe("elg");
+	});
+});
+
+/**
+ * Provides assertions for parsing data to an `Option`.
+ */
+describe("Option", () => {
+	it("can parse", () => {
+		// Arrange.
+		const data = {
+			type: "option",
+			label: "Elgato",
+			disabled: false,
+			value: "elg",
+		};
+
+		// Act.
+		const opt = Option.parse(data);
+
+		// Assert
+		expect(opt.disabled).toBe(false);
+		expect(opt.label).toBe("Elgato");
+		expect(opt.type).toBe("option");
+		expect(opt.value).toBe("elg");
+	});
+
+	it("does not require disabled", () => {
+		// Arrange.
+		const data = {
+			type: "option",
+			label: "Elgato",
+			value: "elg",
+		};
+
+		// Act.
+		const opt = Option.parse(data);
+
+		// Assert
+		expect(opt.disabled).toBeUndefined();
+		expect(opt.label).toBe("Elgato");
+		expect(opt.type).toBe("option");
+		expect(opt.value).toBe("elg");
+	});
+
+	it("requires label", () => {
+		// Arrange.
+		const data = {
+			type: "option",
+			value: "elg",
+		};
+
+		// Act, assert.
+		const result = Option.safeParse(data);
+		expect(result.success).toBe(false);
+	});
+
+	it("requires value", () => {
+		// Arrange.
+		const data = {
+			type: "option",
+			label: "Elgato",
+		};
+
+		// Act, assert.
+		const result = Option.safeParse(data);
+		expect(result.success).toBe(false);
+	});
+
+	it("requires type", () => {
+		// Arrange.
+		const data = {
+			label: "Elgato",
+			value: "elg",
+		};
+
+		// Act, assert.
+		const result = Option.safeParse(data);
+		expect(result.success).toBe(false);
+	});
+});

--- a/src/lists/__tests__/option.test.ts
+++ b/src/lists/__tests__/option.test.ts
@@ -42,7 +42,7 @@ describe("option", () => {
 describe("Option", () => {
 	it("can parse", () => {
 		// Arrange.
-		const data = {
+		const data: Option = {
 			type: "option",
 			label: "Elgato",
 			disabled: false,
@@ -53,15 +53,15 @@ describe("Option", () => {
 		const opt = Option.parse(data);
 
 		// Assert
+		expect(opt.type).toBe("option");
 		expect(opt.disabled).toBe(false);
 		expect(opt.label).toBe("Elgato");
-		expect(opt.type).toBe("option");
 		expect(opt.value).toBe("elg");
 	});
 
 	it("does not require disabled", () => {
 		// Arrange.
-		const data = {
+		const data: Option = {
 			type: "option",
 			label: "Elgato",
 			value: "elg",
@@ -71,9 +71,9 @@ describe("Option", () => {
 		const opt = Option.parse(data);
 
 		// Assert
+		expect(opt.type).toBe("option");
 		expect(opt.disabled).toBeUndefined();
 		expect(opt.label).toBe("Elgato");
-		expect(opt.type).toBe("option");
 		expect(opt.value).toBe("elg");
 	});
 

--- a/src/lists/data-list.ts
+++ b/src/lists/data-list.ts
@@ -1,0 +1,7 @@
+import type { OptionGroup } from "./option-group.js";
+import type { Option } from "./option.js";
+
+/**
+ * Collection of options and/or option groups.
+ */
+export type DataList = (Option | OptionGroup)[];

--- a/src/lists/option-group.ts
+++ b/src/lists/option-group.ts
@@ -4,7 +4,7 @@ import type { DataList } from "./data-list.js";
 import { Option } from "./option.js";
 
 /**
- * Grouping of options.
+ * Serializable structure that represents a grouping of option.
  */
 export type OptionGroup = {
 	/**
@@ -29,7 +29,7 @@ export type OptionGroup = {
 };
 
 /**
- * Grouping of options.
+ * Serializable structure that represents a grouping of option.
  */
 export const OptionGroup: z.ZodMiniType<OptionGroup> = z.object({
 	type: z.literal("option-group"),

--- a/src/lists/option-group.ts
+++ b/src/lists/option-group.ts
@@ -1,0 +1,59 @@
+import { z } from "zod/v4-mini";
+
+import type { DataList } from "./data-list.js";
+import { Option } from "./option.js";
+
+/**
+ * Grouping of options.
+ */
+export type OptionGroup = {
+	/**
+	 * Discriminator property used to identify an option group.
+	 */
+	type: "option-group";
+
+	/**
+	 * Determines whether the option group is disabled; default `false`.
+	 */
+	disabled?: boolean;
+
+	/**
+	 * Options within the group.
+	 */
+	options: DataList;
+
+	/**
+	 * Label that represents the option group.
+	 */
+	label: string;
+};
+
+/**
+ * Grouping of options.
+ */
+export const OptionGroup: z.ZodMiniType<OptionGroup> = z.object({
+	type: z.literal("option-group"),
+	disabled: z.optional(z.boolean()),
+	options: z.lazy(() => z.array(z.union([Option, OptionGroup]))),
+	label: z.string(),
+});
+
+/**
+ * Creates a new option group.
+ * @param props Properties that define the option group.
+ * @returns The option group.
+ */
+export function optionGroup(props: OptionGroupProps): OptionGroup {
+	const { disabled, options, label } = props;
+	return {
+		type: "option-group",
+		disabled,
+		label,
+		options,
+	};
+}
+
+/**
+ * Properties that define an option group.
+ */
+type OptionGroupProps = Omit<OptionGroup, "type">;

--- a/src/lists/option-group.ts
+++ b/src/lists/option-group.ts
@@ -13,7 +13,7 @@ export type OptionGroup = {
 	type: "option-group";
 
 	/**
-	 * Determines whether the option group is disabled; default `false`.
+	 * Determines whether the option group is disabled.
 	 */
 	disabled?: boolean;
 

--- a/src/lists/option-group.ts
+++ b/src/lists/option-group.ts
@@ -4,13 +4,13 @@ import type { DataList } from "./data-list.js";
 import { Option } from "./option.js";
 
 /**
- * Serializable structure that represents a grouping of option.
+ * Serializable structure that represents a group of options.
  */
 export type OptionGroup = {
 	/**
 	 * Discriminator property used to identify an option group.
 	 */
-	type: "option-group";
+	readonly type: "option-group";
 
 	/**
 	 * Determines whether the option group is disabled.
@@ -29,7 +29,7 @@ export type OptionGroup = {
 };
 
 /**
- * Serializable structure that represents a grouping of option.
+ * Serializable structure that represents a group of options.
  */
 export const OptionGroup: z.ZodMiniType<OptionGroup> = z.object({
 	type: z.literal("option-group"),

--- a/src/lists/option-list.ts
+++ b/src/lists/option-list.ts
@@ -1,0 +1,6 @@
+import type { Option } from "./option.js";
+
+/**
+ * Collection of options.
+ */
+export type OptionList = Option[];

--- a/src/lists/option.ts
+++ b/src/lists/option.ts
@@ -1,0 +1,56 @@
+import { z } from "zod/v4-mini";
+
+/**
+ * An option within a list of options or option group.
+ */
+export interface Option {
+	/**
+	 * Discriminator property used to identify an option.
+	 */
+	readonly type: "option";
+
+	/**
+	 * Determines whether the option is disabled.
+	 */
+	disabled?: boolean;
+
+	/**
+	 * Label that represents the option.
+	 */
+	label: string;
+
+	/**
+	 * Value this option represents.
+	 */
+	value: boolean | number | string;
+}
+
+/**
+ * An option within a list of options or option group.
+ */
+export const Option: z.ZodMiniType<Option> = z.object({
+	type: z.literal("option"),
+	disabled: z.optional(z.boolean()),
+	label: z.string(),
+	value: z.union([z.boolean(), z.number(), z.string()]),
+});
+
+/**
+ * Creates a new option.
+ * @param props Properties that define the option.
+ * @returns The option.
+ */
+export function option(props: OptionProps): Option {
+	const { disabled, label, value } = props;
+	return {
+		type: "option",
+		disabled,
+		label,
+		value,
+	};
+}
+
+/**
+ * Properties that define an option.
+ */
+type OptionProps = Omit<Option, "type">;

--- a/src/lists/option.ts
+++ b/src/lists/option.ts
@@ -1,9 +1,9 @@
 import { z } from "zod/v4-mini";
 
 /**
- * An option within a list of options or option group.
+ * Serializable structure that represents an option.
  */
-export interface Option {
+export type Option = {
 	/**
 	 * Discriminator property used to identify an option.
 	 */
@@ -23,10 +23,10 @@ export interface Option {
 	 * Value this option represents.
 	 */
 	value: boolean | number | string;
-}
+};
 
 /**
- * An option within a list of options or option group.
+ * Serializable structure that represents an option.
  */
 export const Option: z.ZodMiniType<Option> = z.object({
 	type: z.literal("option"),


### PR DESCRIPTION
Centralizes the concept of data lists, options, and option groups so that they can be used across DOM and Node.js environments.